### PR TITLE
Feature/fix create collection

### DIFF
--- a/src/Entities/List/ListResponse.php
+++ b/src/Entities/List/ListResponse.php
@@ -48,7 +48,7 @@ class ListResponse extends BaseResponse
      *
      * @param  string  $entityClass  The entity class to map data to
      */
-    public function getDataAs(string $entityClass): array
+    public function getDataAs(string $entityClass): Collection
     {
         return EntityFactory::createCollectionAs($this->data, $entityClass);
     }

--- a/src/Entities/List/ListResponse.php
+++ b/src/Entities/List/ListResponse.php
@@ -2,6 +2,7 @@
 
 namespace Leopaulo88\Asaas\Entities\List;
 
+use Illuminate\Support\Collection;
 use Leopaulo88\Asaas\Concerns\HasPagination;
 use Leopaulo88\Asaas\Entities\BaseResponse;
 use Leopaulo88\Asaas\Support\EntityFactory;
@@ -37,7 +38,7 @@ class ListResponse extends BaseResponse
      * Get the data automatically converted to appropriate entity instances
      * based on the object type of each item
      */
-    public function getData(): array
+    public function getData(): Collection
     {
         return EntityFactory::createCollectionFromArray($this->data);
     }

--- a/src/Support/EntityFactory.php
+++ b/src/Support/EntityFactory.php
@@ -3,6 +3,7 @@
 namespace Leopaulo88\Asaas\Support;
 
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 
 class EntityFactory
@@ -105,25 +106,25 @@ class EntityFactory
         return $data;
     }
 
-    public static function createCollectionFromArray(array $data): array
+    public static function createCollectionFromArray(array $data): Collection
     {
-        return array_map(function ($item) {
+        return collect(array_map(function ($item) {
             if (is_array($item)) {
                 return static::createFromArray($item);
             }
 
             return $item;
-        }, $data);
+        }, $data));
     }
 
-    public static function createCollectionAs(array $data, string $entityClass): array
+    public static function createCollectionAs(array $data, string $entityClass): Collection
     {
-        return array_map(function ($item) use ($entityClass) {
+        return collect(array_map(function ($item) use ($entityClass) {
             if (is_array($item)) {
                 return $entityClass::fromArray($item);
             }
 
             return $item;
-        }, $data);
+        }, $data));
     }
 }


### PR DESCRIPTION
This pull request updates how collections of entities are handled, switching from native PHP arrays to Laravel's `Collection` class for improved consistency and usability across the codebase. The changes primarily affect the return types and internal handling of collections in entity response and factory methods.

**Entity collection handling improvements:**

* Changed the return type of `ListResponse::getData()` from `array` to `Collection`, ensuring that consumers of this method receive a Laravel collection instead of a plain array.
* Updated `EntityFactory::createCollectionFromArray()` and `EntityFactory::createCollectionAs()` to return `Collection` objects instead of arrays, wrapping the results with `collect()`.
* Added the necessary `use Illuminate\Support\Collection;` import statements to files that now utilize the `Collection` class. [[1]](diffhunk://#diff-0cc933ed377ef2c94594f1e269fa90a0e4e9e9152dc15208f2d332d3aa504f85R5) [[2]](diffhunk://#diff-a68318f1f495038d6b14247abe66851c95aa921143934825bc31bbaa67d9e4baR6)…llection